### PR TITLE
fix(ci): migrate profile workflows from deprecated app-id to client-id

### DIFF
--- a/.github/workflows/3d-contrib.yml
+++ b/.github/workflows/3d-contrib.yml
@@ -27,7 +27,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6
@@ -44,7 +44,7 @@ jobs:
       - name: Configure Git for App
         if: github.event_name != 'pull_request'
         env:
-          APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+          APP_ID: ${{ vars.GH_APP_ID }}
         run: |
           git config user.name "JacobPEvans-github-actions[bot]"
           git config user.email "${APP_ID}+JacobPEvans-github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -25,7 +25,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Generate GitHub Metrics

--- a/.github/workflows/snake.yml
+++ b/.github/workflows/snake.yml
@@ -27,7 +27,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6
@@ -46,7 +46,7 @@ jobs:
       - name: Configure Git for App
         if: github.event_name != 'pull_request'
         env:
-          APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+          APP_ID: ${{ vars.GH_APP_ID }}
         run: |
           git config user.name "JacobPEvans-github-actions[bot]"
           git config user.email "${APP_ID}+JacobPEvans-github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- Migrates `snake.yml` and `3d-contrib.yml` from `app-id: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}` to `client-id: ${{ vars.GH_APP_CLIENT_ID }}`
- Updates environment variable from `APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}` to `APP_ID: ${{ vars.GH_APP_ID }}`
- Aligns with Phase 4 workflow centralization: GitHub App auth now uses non-sensitive variables distributed by secrets-sync

**Merge order:** JacobPEvans/secrets-sync#74 → JacobPEvans/.github#268 → this PR

## Changes
- .github/workflows/3d-contrib.yml
- .github/workflows/metrics.yml
- .github/workflows/snake.yml

## Test Plan
- [ ] Profile workflows run without deprecation warnings after merging in order
- [ ] GitHub App token generation uses client-id instead of app-id

🤖 Generated with [Claude Code](https://claude.com/claude-code)