### PR TITLE
fix(profile): use width attribute (height stripped by GitHub), shorter banner text

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 </div>
 
 <p align="center">
-  <a href="https://www.linkedin.com/in/JacobPaulEvans/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn" width="200" /></a>
+  <a href="https://www.linkedin.com/in/JacobPaulEvans/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn" /></a>
   &nbsp;&nbsp;
-  <a href="https://github.com/JacobPEvans" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub" width="200" /></a>
+  <a href="https://github.com/JacobPEvans" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub" /></a>
 </p>
 
 <p align="center">
   <a href="https://docs.jacobpevans.com" target="_blank" rel="noopener noreferrer" aria-label="jacobpevans.com - full architecture documentation">
-    <img src="https://img.shields.io/badge/JACOBPEVANS.COM-4FB3A9?style=for-the-badge" alt="jacobpevans.com" width="600" /></a>
+    <img src="https://img.shields.io/badge/JACOBPEVANS.COM-4FB3A9?style=for-the-badge" alt="jacobpevans.com" width="150" /></a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="https://docs.jacobpevans.com" target="_blank" rel="noopener noreferrer" aria-label="docs.jacobpevans.com - full architecture documentation">
-    <img src="https://img.shields.io/badge/JACOBPEVANS.COM-4FB3A9?style=for-the-badge" alt="jacobpevans.com" width="50%" /></a>
+    <img src="https://img.shields.io/badge/JACOBPEVANS.COM-4FB3A9?style=for-the-badge" alt="jacobpevans.com" width="400" /></a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  <a href="https://docs.jacobpevans.com" target="_blank" rel="noopener noreferrer" aria-label="jacobpevans.com - full architecture documentation">
+  <a href="https://docs.jacobpevans.com" target="_blank" rel="noopener noreferrer" aria-label="docs.jacobpevans.com - full architecture documentation">
     <img src="https://img.shields.io/badge/JACOBPEVANS.COM-4FB3A9?style=for-the-badge" alt="jacobpevans.com" width="150" /></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -5,15 +5,14 @@
 </div>
 
 <p align="center">
-  <a href="https://www.linkedin.com/in/JacobPaulEvans/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn" height="56" /></a>
+  <a href="https://www.linkedin.com/in/JacobPaulEvans/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn" width="200" /></a>
   &nbsp;&nbsp;
-  <a href="https://github.com/JacobPEvans" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub" height="56" /></a>
+  <a href="https://github.com/JacobPEvans" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub" width="200" /></a>
 </p>
 
 <p align="center">
-  <a href="https://docs.jacobpevans.com" target="_blank" rel="noopener noreferrer" aria-label="docs.jacobpevans.com - full architecture documentation">
-    <img src="https://img.shields.io/badge/DOCS.JACOBPEVANS.COM-4FB3A9?style=for-the-badge" alt="docs.jacobpevans.com" height="112" />
-  </a>
+  <a href="https://docs.jacobpevans.com" target="_blank" rel="noopener noreferrer" aria-label="jacobpevans.com - full architecture documentation">
+    <img src="https://img.shields.io/badge/JACOBPEVANS.COM-4FB3A9?style=for-the-badge" alt="jacobpevans.com" width="600" /></a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="https://docs.jacobpevans.com" target="_blank" rel="noopener noreferrer" aria-label="docs.jacobpevans.com - full architecture documentation">
-    <img src="https://img.shields.io/badge/JACOBPEVANS.COM-4FB3A9?style=for-the-badge" alt="jacobpevans.com" width="150" /></a>
+    <img src="https://img.shields.io/badge/JACOBPEVANS.COM-4FB3A9?style=for-the-badge" alt="jacobpevans.com" width="50%" /></a>
 </p>
 
 ---


### PR DESCRIPTION
## Why the previous size changes did nothing

GitHub's README HTML sanitizer ignores or strips the \`height\` attribute on \`<img>\` tags. My height=56 and height=112 on the social badges and docs banner therefore rendered at the badges' intrinsic size (~28px tall), which is why nothing looked bigger.

\`width\` IS respected — the existing XKCD comic uses \`width="400"\` and renders at 400px wide. Switching all badges to width fixes it.

## Changes

| Badge | Before | After | Approx rendered height |
| --- | --- | --- | --- |
| LinkedIn | height=56 (stripped) | width=200 | ~67px |
| GitHub | height=56 (stripped) | width=200 | ~67px |
| Docs banner | height=112 (stripped) | width=600 | ~80px |

Also shortened banner text from \`DOCS.JACOBPEVANS.COM\` to \`JACOBPEVANS.COM\` per user spec. Link target unchanged (still \`https://docs.jacobpevans.com\`).

Banner should now render at ~3x the height of body text and ~3x wider than the social badges — visually unmistakable as a call to action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)