### PR TITLE
chore(ci): add gh-aw-pin-refresh.yml

### DIFF
--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -1,0 +1,32 @@
+name: gh-aw pin refresh
+
+on:
+  schedule:
+    - cron: "0 12 * * 1"  # Monday 12:00 UTC (7am CDT / 6am CST)
+    - cron: "0 12 * * 4"  # Thursday 12:00 UTC (7am CDT / 6am CST)
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: 'compile = refresh SHA pins only; upgrade = full gh-aw infrastructure update'
+        type: choice
+        default: 'compile'
+        options:
+          - compile
+          - upgrade
+
+permissions: {}
+
+concurrency:
+  group: gh-aw-pin-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: JacobPEvans/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
+    with:
+      operation: ${{ inputs.operation || 'compile' }}
+    secrets:
+      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
The Distributor propagation PR.

## Workflow

`gh-aw-pin-refresh.yml` — sourced from [JacobPEvans/ai-workflows](https://github.com/JacobPEvans/ai-workflows)

## Why this repo

This repo is missing the core AI workflow suite; `gh-aw-pin-refresh.yml` is the highest-priority gap and keeps all other workflow action pins up-to-date automatically.

## Notes

- This workflow uses the `run-claude-code` composite action from `ai-workflows`, which handles commit signing via the `JacobPEvans-claude` GitHub App. No additional secrets configuration is needed if the App is already installed.
- Review the workflow configuration before merging — some workflows reference environment variables or secrets that may need to be set in this repo's settings.

## Checklist

- [ ] Workflow file looks correct for this repo's structure
- [ ] Required secrets/vars are configured (if any)
- [ ] Base branch trigger is appropriate

---

Generated by The Distributor — prompt source: `https://claude.ai/code`
