### PR TITLE
fix(profile): banner sizing, de-link typing svg, taller typing banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 <div align="center">
-  <a href="https://git.io/typing-svg" target="_blank" rel="noopener noreferrer" aria-label="Typing animation">
-    <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&weight=600&size=48&duration=2000&pause=800&color=58A6FF&center=true&vCenter=true&repeat=true&width=700&height=70&lines=Claude+Whisperer;Model+Wrangler;Automator;Data+Diver;Toil+Terminator;Nix+Evangelist;Home+Lab+Addict;Recovering+CS+Major;Reef+Keeper" alt="Rotating taglines: Claude Whisperer, Model Wrangler, Automator, Data Diver, Toil Terminator, Nix Evangelist, Home Lab Addict, Recovering CS Major, Reef Keeper" />
-  </a>
+  <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&weight=600&size=48&duration=2000&pause=800&color=58A6FF&center=true&vCenter=true&repeat=true&width=700&height=90&lines=Claude+Whisperer;Model+Wrangler;Automator;Data+Diver;Toil+Terminator;Nix+Evangelist;Home+Lab+Addict;Recovering+CS+Major;Reef+Keeper" alt="Rotating taglines: Claude Whisperer, Model Wrangler, Automator, Data Diver, Toil Terminator, Nix Evangelist, Home Lab Addict, Recovering CS Major, Reef Keeper" />
 </div>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 </div>
 
 <p align="center">
-  <a href="https://www.linkedin.com/in/JacobPaulEvans/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/LinkedIn-grey?style=social" alt="LinkedIn" width="195" /></a>
-  <a href="https://github.com/JacobPEvans" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/GitHub-grey?style=social" alt="GitHub" width="195" /></a>
+  <a href="https://www.linkedin.com/in/JacobPaulEvans/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=plastic" alt="LinkedIn" width="195" /></a>
+  <a href="https://github.com/JacobPEvans" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/GitHub-181717?style=plastic" alt="GitHub" width="195" /></a>
 </p>
 
 <p align="center">
   <a href="https://docs.jacobpevans.com" target="_blank" rel="noopener noreferrer" aria-label="docs.jacobpevans.com - full architecture documentation">
-    <img src="https://img.shields.io/badge/JACOBPEVANS.COM-4FB3A9?style=for-the-badge" alt="jacobpevans.com" width="400" /></a>
+    <img src="https://img.shields.io/badge/JACOBPEVANS.COM-4FB3A9?style=plastic" alt="jacobpevans.com" width="400" /></a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 </div>
 
 <p align="center">
-  <a href="https://www.linkedin.com/in/JacobPaulEvans/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn" width="290" /></a>
-  <a href="https://github.com/JacobPEvans" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub" width="290" /></a>
+  <a href="https://www.linkedin.com/in/JacobPaulEvans/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0id2hpdGUiIGQ9Ik0yMC40NDcgMjAuNDUyaC0zLjU1NHYtNS41NjljMC0xLjMyOC0uMDI3LTMuMDM3LTEuODUyLTMuMDM3LTEuODUzIDAtMi4xMzYgMS40NDUtMi4xMzYgMi45Mzl2NS42NjdIOS4zNTFWOWgzLjQxNHYxLjU2MWguMDQ2Yy40NzctLjkgMS42MzctMS44NSAzLjM3LTEuODUgMy42MDEgMCA0LjI2NyAyLjM3IDQuMjY3IDUuNDU1djYuMjg2ek01LjMzNyA3LjQzM2MtMS4xNDQgMC0yLjA2My0uOTI2LTIuMDYzLTIuMDY1IDAtMS4xMzguOTItMi4wNjMgMi4wNjMtMi4wNjMgMS4xNCAwIDIuMDY0LjkyNSAyLjA2NCAyLjA2MyAwIDEuMTM5LS45MjUgMi4wNjUtMi4wNjQgMi4wNjV6bTEuNzgyIDEzLjAxOUgzLjU1NVY5aDMuNTY0djExLjQ1MnpNMjIuMjI1IDBIMS43NzFDLjc5MiAwIDAgLjc3NCAwIDEuNzI5djIwLjU0MkMwIDIzLjIyNy43OTIgMjQgMS43NzEgMjRoMjAuNDUxQzIzLjIgMjQgMjQgMjMuMjI3IDI0IDIyLjI3MVYxLjcyOUMyNCAuNzc0IDIzLjIgMCAyMi4yMjIgMGguMDAzeiIvPjwvc3ZnPg==" alt="LinkedIn" width="290" height="73" /></a>
+  <a href="https://github.com/JacobPEvans" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub" width="250" height="73" /></a>
 </p>
 
 <p align="center">
   <a href="https://docs.jacobpevans.com" target="_blank" rel="noopener noreferrer" aria-label="docs.jacobpevans.com - full architecture documentation">
-    <img src="https://img.shields.io/badge/JACOBPEVANS.COM-4FB3A9?style=for-the-badge" alt="jacobpevans.com" width="400" /></a>
+    <img src="https://img.shields.io/badge/JACOBPEVANS.COM-4FB3A9?style=for-the-badge" alt="jacobpevans.com" width="400" height="73" /></a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 </div>
 
 <p align="center">
-  <a href="https://www.linkedin.com/in/JacobPaulEvans/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge" alt="LinkedIn" width="238" height="73" /></a>
-  <a href="https://github.com/JacobPEvans" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub" width="250" height="73" /></a>
+  <a href="https://www.linkedin.com/in/JacobPaulEvans/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge" alt="LinkedIn" width="192" height="59" /></a>
+  <a href="https://github.com/JacobPEvans" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub" width="201" height="59" /></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 </div>
 
 <p align="center">
-  <a href="https://www.linkedin.com/in/JacobPaulEvans/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=plastic" alt="LinkedIn" width="195" /></a>
-  <a href="https://github.com/JacobPEvans" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/GitHub-181717?style=plastic" alt="GitHub" width="195" /></a>
+  <a href="https://www.linkedin.com/in/JacobPaulEvans/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn" width="290" /></a>
+  <a href="https://github.com/JacobPEvans" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub" width="290" /></a>
 </p>
 
 <p align="center">
   <a href="https://docs.jacobpevans.com" target="_blank" rel="noopener noreferrer" aria-label="docs.jacobpevans.com - full architecture documentation">
-    <img src="https://img.shields.io/badge/JACOBPEVANS.COM-4FB3A9?style=plastic" alt="jacobpevans.com" width="400" /></a>
+    <img src="https://img.shields.io/badge/JACOBPEVANS.COM-4FB3A9?style=for-the-badge" alt="jacobpevans.com" width="400" /></a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </div>
 
 <p align="center">
-  <a href="https://www.linkedin.com/in/JacobPaulEvans/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0id2hpdGUiIGQ9Ik0yMC40NDcgMjAuNDUyaC0zLjU1NHYtNS41NjljMC0xLjMyOC0uMDI3LTMuMDM3LTEuODUyLTMuMDM3LTEuODUzIDAtMi4xMzYgMS40NDUtMi4xMzYgMi45Mzl2NS42NjdIOS4zNTFWOWgzLjQxNHYxLjU2MWguMDQ2Yy40NzctLjkgMS42MzctMS44NSAzLjM3LTEuODUgMy42MDEgMCA0LjI2NyAyLjM3IDQuMjY3IDUuNDU1djYuMjg2ek01LjMzNyA3LjQzM2MtMS4xNDQgMC0yLjA2My0uOTI2LTIuMDYzLTIuMDY1IDAtMS4xMzguOTItMi4wNjMgMi4wNjMtMi4wNjMgMS4xNCAwIDIuMDY0LjkyNSAyLjA2NCAyLjA2MyAwIDEuMTM5LS45MjUgMi4wNjUtMi4wNjQgMi4wNjV6bTEuNzgyIDEzLjAxOUgzLjU1NVY5aDMuNTY0djExLjQ1MnpNMjIuMjI1IDBIMS43NzFDLjc5MiAwIDAgLjc3NCAwIDEuNzI5djIwLjU0MkMwIDIzLjIyNy43OTIgMjQgMS43NzEgMjRoMjAuNDUxQzIzLjIgMjQgMjQgMjMuMjI3IDI0IDIyLjI3MVYxLjcyOUMyNCAuNzc0IDIzLjIgMCAyMi4yMjIgMGguMDAzeiIvPjwvc3ZnPg==" alt="LinkedIn" width="290" height="73" /></a>
+  <a href="https://www.linkedin.com/in/JacobPaulEvans/" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge" alt="LinkedIn" width="238" height="73" /></a>
   <a href="https://github.com/JacobPEvans" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub" width="250" height="73" /></a>
 </p>
 


### PR DESCRIPTION
## Summary

Profile README polish covering 3 distinct asks plus a triple-check of the snake animation refresh.

## Changes in this commit

### 1. Typing-banner link removed
The `<a href="https://git.io/typing-svg">` wrapper around the typing animation `<img>` is gone. Image is now plain — no link.

### 2. Typing-banner height bumped 70 → 90
Font size in the URL is `size=48` (Fira Code). At `height=70` the rendered text was getting clipped on ascenders/descenders. Bumped query param to `height=90` to give full clearance.

### 3. External-link target verification
LinkedIn, GitHub, and JACOBPEVANS.COM all already carry `target="_blank" rel="noopener noreferrer"` — no change needed:

```
$ grep -nE 'target="_blank"' README.md | head -3
6:  <a href="https://www.linkedin.com/in/JacobPaulEvans/" target="_blank" rel="noopener noreferrer">…
7:  <a href="https://github.com/JacobPEvans" target="_blank" rel="noopener noreferrer">…
11: <a href="https://docs.jacobpevans.com" target="_blank" rel="noopener noreferrer" aria-label="…">
```

If they're still opening in the current window on the rendered profile, that's GitHub's HTML sanitization stripping the attribute — outside what we can control via markdown. The attributes are correct.

## Snake-animation refresh (triple-checked)

Per request, manually triggered `snake.yml` to confirm the fix from PR #62 is working end-to-end:

| Check | Result |
|---|---|
| Workflow `outputs:` path | `assets/img/github-snake.svg` + `assets/img/github-snake-dark.svg?palette=github-dark` |
| README references | All 3 srcset/img URLs point to `output/assets/img/github-snake-*.svg` |
| Live SVG at consumer URL | HTTP 200, 100KB, served from `output/assets/img/` |
| Manual run (workflow_dispatch) 26412540929 | succeeded; wrote SVGs to `assets/img/`; diff against output branch = none (today's SVG already on output from earlier scheduled run) → `pull-request-operation: none` — correct "already current" no-op |
| Daily cron | `0 12 * * *` UTC in `snake.yml` |
| Today's output-branch commit | `3de0943 chore: update snake animation (#64)` at 16:34 UTC — confirms today's daily refresh landed normally |

Conclusion: snake animation is refreshing daily as intended. The path mismatch bug from before PR #62 is fully resolved.

## Banner sizing (from earlier commits on this PR)

Combined LinkedIn (192) + ~5px inline gap + GitHub (201) = ~398px, vs JACOBPEVANS.COM 400px. Within "a pixel or two" of edge-alignment.

| Badge | Width × Height | Style |
|---|---|---|
| LinkedIn | 192 × 59 | `for-the-badge`, brand color, no logo (shields.io blocks `logo=linkedin`) |
| GitHub | 201 × 59 | `for-the-badge`, brand color, `logo=github&logoColor=white` |
| JACOBPEVANS.COM | 400 × 73 | `for-the-badge`, brand color, no logo |

LinkedIn and GitHub are matched in height to each other (~59px); JACOBPEVANS.COM stays at ~73px — height matching across all 3 + edge-aligned widths are mathematically exclusive at these aspect ratios.

## Preview before merging

https://github.com/JacobPEvans/JacobPEvans/blob/fix/banner-style-plastic/README.md

## Test Plan

- [x] markdownlint passes
- [x] All shields.io and typing-svg URLs return HTTP 200
- [x] target="_blank" verified on all 3 external links
- [x] Snake workflow manually triggered → succeeded → output path correct
- [x] All review threads resolved
- [x] CI green, CodeQL 0 alerts
- [ ] Visual review on the branch README

Assisted-by: Claude <noreply@anthropic.com>