### PR TITLE
[routine:inspector] no-scripts: extract readme-section inline bash to scripts/

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -92,31 +92,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Validate required sections
-        run: |
-          if [ ! -f ".readme-validator.yaml" ]; then
-            echo "No .readme-validator.yaml found, skipping section validation"
-            exit 0
-          fi
-
-          errors=0
-
-          # Parse required sections from config
-          while IFS= read -r section; do
-            [ -z "$section" ] && continue
-            if ! grep -q "^### ${section}$" README.md; then
-              echo "::error::Required section missing: '### ${section}'"
-              ((errors++))
-            else
-              echo "Found required section: '### ${section}'"
-            fi
-          done < <(yq '.required_sections[]' .readme-validator.yaml 2>/dev/null)
-
-          if [ "$errors" -gt 0 ]; then
-            echo "README validation failed: ${errors} missing section(s)"
-            exit 1
-          fi
-
-          echo "All required sections present"
+        run: bash scripts/validate-readme-sections.sh
 
   # ==========================================================================
   # MERGE GATE - The ONLY required check in branch protection

--- a/scripts/validate-readme-sections.sh
+++ b/scripts/validate-readme-sections.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -f ".readme-validator.yaml" ]; then
+  echo "No .readme-validator.yaml found, skipping section validation"
+  exit 0
+fi
+
+errors=0
+
+# Parse required sections from config
+while IFS= read -r section; do
+  [ -z "$section" ] && continue
+  if ! grep -q "^### ${section}$" README.md; then
+    echo "::error::Required section missing: '### ${section}'"
+    ((errors++))
+  else
+    echo "Found required section: '### ${section}'"
+  fi
+done < <(yq '.required_sections[]' .readme-validator.yaml 2>/dev/null)
+
+if [ "$errors" -gt 0 ]; then
+  echo "README validation failed: ${errors} missing section(s)"
+  exit 1
+fi
+
+echo "All required sections present"


### PR DESCRIPTION
The Inspector report.

## Rule

`no-scripts` — multi-line inline bash in workflow run-blocks should live in versioned scripts

## Finding

File: `.github/workflows/ci-gate.yml`
Line range: `L95-L119`
Severity: medium (20-line run-block with `if`, `while`, `for` control flow)

## Action

Extracted the README-section validation logic to `scripts/validate-readme-sections.sh` and replaced the 20-line inline run-block with `run: bash scripts/validate-readme-sections.sh`. No semantic change — same inputs, same outputs, same exit codes. Post-edit YAML parse passed.

## Provenance

- **Generated by:** The Inspector — cloud routine, daily at 06:00 UTC.
- **Triggered:** Today's rotation landed on rule `no-scripts` (day-of-year mod 3 = 2).
- **Why this PR:** `JacobPEvans-personal/JacobPEvans` had the largest extractable run-block (20 lines) of `no-scripts` in the active-repo scan.
- **State:** `inspector-state` gist — tracks per-(repo, rule) cooldowns and content-hash caches.
- **Label:** `cloud-routine`