### PR TITLE
docs(JacobPEvans): add .gitignore - config hygiene fix [routine:daily-polish]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# macOS
+.DS_Store
+
+# Node / npm (local tooling)
+node_modules/
+npm-debug.log*
+
+# Editor artifacts
+.vscode/
+*.swp
+*.swo
+
+# Local environment
+.env
+.envrc.local


### PR DESCRIPTION
Daily Polish auto-generated PR.

## Checks before fix

3/5 passing.

Failing checks:
- **README Quality**: Missing installation/setup section, usage section, and CI workflow status badge (profile README; install/usage N/A for this repo type)
- **Config Hygiene**: `.gitignore` not present

## Fixes applied

- **Config Hygiene (.gitignore)**: Added `.gitignore` covering macOS artifacts (`.DS_Store`), Node/npm tooling (`node_modules/`), editor artifacts, and local environment files. This is appropriate for a profile repo that uses `npx markdownlint-cli2` locally.

## Checks after fix (self-verification)

Re-evaluated against the `docs/daily-polish/JacobPEvans-2026-06-16` branch:

| Check | Before | After |
|---|---|---|
| README Quality | FAIL | FAIL (install/usage N/A for profile repo) |
| CLAUDE.md | PASS | PASS |
| Repo Description | PASS | PASS |
| Config Hygiene | FAIL | PASS (.gitignore added) |
| Release Hygiene | PASS | PASS |

**Improved from 3 -> 4 passing.**

Note: README Quality sub-checks for installation/setup and usage sections are not applicable to a GitHub profile README. The CI gate (`ci-gate.yml`) validates `### About Me` section which is present; adding placeholder install/usage content would degrade the profile and likely conflict with `.readme-validator.yaml`.

---

## Provenance

- **Generated by:** [Daily Polish](https://github.com/JacobPEvans-personal/.github) - cloud routine, daily at 04:00 UTC
- **Triggered:** Scheduled run on 2026-06-16; `JacobPEvans` selected from rotation (excluded last_polished=cc-edge-claude-code-otel; alphabetical tiebreaker among top-3 candidates all scoring 0)
- **Why this PR:** `JacobPEvans` had 2/5 checks failing (README Quality, Config Hygiene); Config Hygiene fixed by adding `.gitignore`
- **State:** [daily-polish-state gist](https://gist.github.com/JacobPEvans-personal/3973727cb935d2960b17ae2d4e9fbdda)
- **Label:** `cloud-routine`
