### PR TITLE
docs(JacobPEvans): add CI and license badges [routine:daily-polish]

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
     <img src="https://img.shields.io/badge/JACOBPEVANS.COM-4FB3A9?style=for-the-badge" alt="jacobpevans.com" width="400" height="73" /></a>
 </p>
 
+<p align="center">
+  <a href="https://github.com/JacobPEvans-personal/JacobPEvans/actions/workflows/ci-gate.yml" target="_blank" rel="noopener noreferrer"><img src="https://github.com/JacobPEvans-personal/JacobPEvans/actions/workflows/ci-gate.yml/badge.svg" alt="CI Gate" /></a>
+  <a href="https://opensource.org/licenses/Apache-2.0" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License: Apache 2.0" /></a>
+</p>
+
 ---
 
 <p align="center">


### PR DESCRIPTION
Daily Polish auto-generated PR.

## Checks before fix

3/5 passing.

Failing checks:
- **README Quality**: missing CI badge and license badge/mention
- **Config Hygiene**: `.gitignore` absent (not addressable via documentation-only scope)

## Fixes applied

- **README Quality**: Added CI Gate badge (linking to `ci-gate.yml` workflow) and Apache 2.0 license badge to the header badge section.

## Checks after fix (self-verification)

Re-evaluated against the `docs/daily-polish/JacobPEvans-2026-06-19` branch: improved from 3 → 4 passing.

Note: `.gitignore` absence (Config Hygiene) is out of scope for this routine (documentation-only), so that check remains failing.

---

## Provenance

- **Generated by:** [Daily Polish](https://github.com/JacobPEvans-personal/.github/blob/main/routines/daily-polish.prompt.md) - cloud routine, daily at 04:00 UTC
- **Triggered:** Scheduled run on 2026-06-19
- **Why this PR:** `JacobPEvans` was selected from the rotation (state gist `daily-polish-state`) via tiebreaker (alphabetical); 2/5 sections failed.
- **State:** [daily-polish-state gist](https://gist.github.com/JacobPEvans-personal/3973727cb935d2960b17ae2d4e9fbdda)
- **Label:** `cloud-routine`
