### PR TITLE
fix(ci): stop generation workflows from gating PRs; drop Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"

--- a/.github/workflows/3d-contrib.yml
+++ b/.github/workflows/3d-contrib.yml
@@ -7,11 +7,9 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('pr-validate-{0}', github.run_id) || 'output-branch-push' }}
+  group: output-branch-push
   cancel-in-progress: false
 
 permissions:
@@ -43,7 +41,6 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
 
       - name: Open signed PR to output
-        if: github.event_name != 'pull_request'
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
@@ -58,7 +55,7 @@ jobs:
           add-paths: profile-3d-contrib/
 
       - name: Squash-merge the PR
-        if: github.event_name != 'pull_request' && steps.cpr.outputs.pull-request-operation == 'created'
+        if: steps.cpr.outputs.pull-request-operation == 'created'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -73,13 +73,13 @@ jobs:
     name: Markdown Lint
     needs: changes
     if: needs.changes.outputs.markdown == 'true'
-    uses: JacobPEvans/.github/.github/workflows/_markdown-lint.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_markdown-lint.yml@main
 
   file-size:
     name: File Size
     needs: changes
     if: needs.changes.outputs.markdown == 'true' || needs.changes.outputs.config == 'true'
-    uses: JacobPEvans/.github/.github/workflows/_file-size.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_file-size.yml@main
 
   readme-sections:
     name: README Sections

--- a/.github/workflows/snake.yml
+++ b/.github/workflows/snake.yml
@@ -7,11 +7,9 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('pr-validate-{0}', github.run_id) || 'output-branch-push' }}
+  group: output-branch-push
   cancel-in-progress: false
 
 permissions:
@@ -45,7 +43,6 @@ jobs:
             assets/img/github-snake-dark.svg?palette=github-dark
 
       - name: Open signed PR to output
-        if: github.event_name != 'pull_request'
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
@@ -60,7 +57,7 @@ jobs:
           add-paths: assets/img/
 
       - name: Squash-merge the PR
-        if: github.event_name != 'pull_request' && steps.cpr.outputs.pull-request-operation == 'created'
+        if: steps.cpr.outputs.pull-request-operation == 'created'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
## Why

Generation workflows (snake, 3d-contrib, metrics) succeeded on schedule Jun 21 and began failing Jun 22 — the commit-signing GitHub App appears to have moved to the `dryvist` org, so this repo can no longer mint a token. Separately, `snake.yml` and `3d-contrib.yml` ran on `pull_request` and their first step mints that app token, so the required `generate` check failed on every PR (Dependabot PRs never receive the secret at all). PRs #124/#125 are blocked by this.

## What

- Remove the `pull_request` trigger from `snake.yml` and `3d-contrib.yml` (and the now-dead PR-mode guards + `pr-validate` concurrency branch). These jobs only commit generated assets to `output`.
- Delete `.github/dependabot.yml` — Renovate-only (`renovate.json` already configured).

## Follow-ups

- Ruleset `11490473`: drop `generate` from required checks, add `CI Gate`.
- Reinstall the signing GitHub App on `JacobPEvans-personal` + reset `GH_APP_CLIENT_ID`/`GH_APP_PRIVATE_KEY`.