### PR TITLE
fix(ci): metrics user -> github.repository_owner (was dead 'JacobPEvans')

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -32,7 +32,7 @@ jobs:
         uses: lowlighter/metrics@65836723097537a54cd8eb90f61839426b4266b6 # v3.34
         with:
           token: ${{ steps.app-token.outputs.token }}
-          user: JacobPEvans
+          user: ${{ github.repository_owner }}
           template: classic
           base: header, activity, community, repositories
           config_timezone: America/Detroit


### PR DESCRIPTION
metrics.yml hardcoded `user: JacobPEvans`, which 404s post-migration, so lowlighter/metrics hung at Rendering until the 15-min timeout — metrics has been cancelled daily. Switch to `${{ github.repository_owner }}` to match snake.yml and 3d-contrib.yml.